### PR TITLE
Fix failing smoke tests for summarize_plan.py

### DIFF
--- a/scripts/summarize_plan.command
+++ b/scripts/summarize_plan.command
@@ -3,4 +3,4 @@
 # Go to the scripts directory
 cd "$(dirname "$0")"
 
-python3 summarize_plan.py $* > /dev/null 2> /dev/null &
+python3 summarize_plan.py $* &

--- a/scripts/summarize_plan.py
+++ b/scripts/summarize_plan.py
@@ -135,6 +135,10 @@ def listen_for_updates(
     global_args = args
     global_config = config
 
+    # The Bottle app logs requests to the terminal by default, which crashes
+    # the app if it's running without a terminal
+    sys.stdout = sys.stderr = os.devnull
+
     messenger.log_status(
         TaskStatus.RUNNING, f"Listening for changes on http://localhost:{args.port}."
     )


### PR DESCRIPTION
The quick fix of redirecting everything to /dev/null also made the tests fail, since they expect some output in some cases.