### PR TITLE
Automatically open PCO live during MCR setup

### DIFF
--- a/scripts/config/mcr_setup_tasks.json
+++ b/scripts/config/mcr_setup_tasks.json
@@ -188,7 +188,10 @@
 			"name": "follow_Planning_Center_plan",
 			"description": "On Planning Center Online, open the live view of today's plan.",
 			"prerequisites": [
-				"turn_everything_on"
+				"check_streaming_platforms",
+				"check_live_feeds",
+				"save_vMix_preset",
+				"publish_sermon_notes"
 			]
 		}
 	]

--- a/scripts/lib/mcr_setup.py
+++ b/scripts/lib/mcr_setup.py
@@ -1,8 +1,9 @@
 import inspect
 from typing import Set, Tuple
 
+import external_services
 from autochecklist import Messenger, ProblemLevel, TaskStatus
-from config import McrSetupConfig
+from config import Config, McrSetupConfig
 from external_services import (
     Plan,
     PlanningCenterClient,
@@ -237,4 +238,14 @@ def generate_backup_slides(
     messenger.log_status(
         TaskStatus.DONE,
         f"Generated {len(slides)} slides in {config.assets_by_service_dir.as_posix()}.",
+    )
+
+
+def follow_Planning_Center_plan(
+    pco_client: PlanningCenterClient, config: Config
+) -> None:
+    plan = pco_client.find_plan_by_date(dt=config.start_time.date())
+    external_services.launch_firefox(
+        config.live_view_url.fill({"SERVICE_ID": plan.id.plan}),
+        fullscreen=False,
     )


### PR DESCRIPTION
Closes #610.

Adding the link may be a bit tricky since the messages are static strings in [mcr_setup_tasks.json](https://github.com/recc-tech/tech/blob/main/scripts/config/mcr_setup_tasks.json) but the PCO Live URL includes the plan ID, which changes from week to week. It's easier to just automate the task and open the web page.