### PR TITLE
Generate summary of visuals notes

### DIFF
--- a/scripts/config/config.toml
+++ b/scripts/config/config.toml
@@ -159,9 +159,11 @@ host2_title_key = "8e81a0df-26b2-42ab-a5ae-5c79199a53d7"
 timeout_seconds = 30.0
 
 [plan_summary]
-# Categories of notes that will be shown (e.g., visuals is relevant, vocals is
-# probably not)
-note_categories = ["Visuals"]
+# Categories of notes that will be shown in the plan summary (e.g., visuals is
+# relevant, vocals is probably not)
+tech_note_categories = ["Visuals"]
+# Categories of notes that will be included in the vocal notes summary
+vocal_note_categories = ["Vocals"]
 # Lines in the announcement-related sections of the plan to ignore
 # (case-insensitive)
 announcements_to_ignore = [

--- a/scripts/config/config.toml
+++ b/scripts/config/config.toml
@@ -164,6 +164,8 @@ timeout_seconds = 30.0
 tech_note_categories = ["Visuals"]
 # Categories of notes that will be included in the vocal notes summary
 vocal_note_categories = ["Vocals"]
+# Where to save the vocals notes summary
+vocals_notes_file = "%{folder.plan_summaries}%/%{args.startup_ymd}%-vocals-notes.html"
 # Lines in the announcement-related sections of the plan to ignore
 # (case-insensitive)
 announcements_to_ignore = [

--- a/scripts/config/src/config.py
+++ b/scripts/config/src/config.py
@@ -501,6 +501,7 @@ class Config(BaseConfig):
             self.vocals_note_categories = set(
                 reader.get_str_list("plan_summary.vocal_note_categories")
             )
+            self.vocals_notes_file = reader.get_file("plan_summary.vocals_notes_file")
             self.announcements_to_ignore = {
                 a.lower()
                 for a in reader.get_str_list("plan_summary.announcements_to_ignore")

--- a/scripts/config/src/config.py
+++ b/scripts/config/src/config.py
@@ -496,7 +496,10 @@ class Config(BaseConfig):
 
             # Plan Summaries
             self.plan_summary_note_categories = set(
-                reader.get_str_list("plan_summary.note_categories")
+                reader.get_str_list("plan_summary.tech_note_categories")
+            )
+            self.vocals_note_categories = set(
+                reader.get_str_list("plan_summary.vocal_note_categories")
             )
             self.announcements_to_ignore = {
                 a.lower()

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -27,6 +27,9 @@ from .summarize_plan import (
     get_plan_summary,
     get_vocals_notes,
     load_plan_summary,
+    load_vocals_notes,
     plan_summary_diff_to_html,
     plan_summary_to_json,
+    vocals_notes_to_html,
+    vocals_notes_to_json,
 )

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -25,6 +25,7 @@ from .summarize_plan import (
     PlanSummaryDiff,
     diff_plan_summaries,
     get_plan_summary,
+    get_vocals_notes,
     load_plan_summary,
     plan_summary_diff_to_html,
     plan_summary_to_json,

--- a/scripts/lib/summarize_plan.py
+++ b/scripts/lib/summarize_plan.py
@@ -411,6 +411,17 @@ def diff_plan_summaries(old: PlanSummary, new: PlanSummary) -> PlanSummaryDiff:
     )
 
 
+def get_vocals_notes(
+    client: PlanningCenterClient, config: Config, dt: date
+) -> List[AnnotatedSong]:
+    plan = client.find_plan_by_date(dt)
+    sections = client.find_plan_items(
+        plan.id, include_songs=True, include_item_notes=True
+    )
+    songs = _get_songs(sections, note_categories=config.vocals_note_categories)
+    return [s for sec in songs for s in sec]
+
+
 _SUPERHEADER_CLS = "superheader"
 _BLOCK_START_CLS = "block-start"
 _BLOCK_END_CLS = "block-end"

--- a/scripts/lib/summarize_plan.py
+++ b/scripts/lib/summarize_plan.py
@@ -414,6 +414,10 @@ def diff_plan_summaries(old: PlanSummary, new: PlanSummary) -> PlanSummaryDiff:
 def get_vocals_notes(
     client: PlanningCenterClient, config: Config, dt: date
 ) -> List[AnnotatedSong]:
+    """
+    List the songs in the plan on the given date, along with their vocals
+    notes.
+    """
     plan = client.find_plan_by_date(dt)
     sections = client.find_plan_items(
         plan.id, include_songs=True, include_item_notes=True
@@ -980,6 +984,76 @@ def plan_summary_diff_to_html(
 """.lstrip()
 
 
+def _note_to_html(note: ItemNote, include_heading: bool) -> str:
+    paragraphs = [
+        p.strip().replace("\n", "<br />") for p in note.contents.split("\n\n")
+    ]
+    paragraphs = "\n".join([f"<p>\n{_indent(p, 1)}\n</p>" for p in paragraphs])
+    heading = f"<h4>{note.category}:</h4>\n" if include_heading else ""
+    return f"{heading}{paragraphs}"
+
+
+def _make_vocals_notes_section(song: AnnotatedSong, i: int) -> str:
+    authors_header = (
+        f"<h3>{html.escape(song.song.author)}</h3>" if song.song.author else ""
+    )
+    notes = "\n".join(
+        [
+            _note_to_html(note, include_heading=len(song.notes) > 1)
+            for note in song.notes
+        ]
+    )
+    return f"""
+<section id='song-{i}'>
+<a href='#song-{i}'><h2>{html.escape(song.song.title)}</h2></a>
+{authors_header}
+
+{notes}
+</section>
+    """.strip()
+
+
+def vocals_notes_to_html(songs: List[AnnotatedSong]) -> str:
+    """
+    Generate an HTML document to visualize the given songs and vocal notes.
+    """
+    body = "\n<hr />\n".join(
+        [_make_vocals_notes_section(s, i) for i, s in enumerate(songs, start=1)]
+    )
+    return f"""
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Plan Summary</title>
+        <link rel='shortcut icon' href='{_ICON_PATH.as_posix()}' />
+        <style>
+            html {{
+                /*
+                 * Let the user scroll past the bottom of the page so that they
+                 * can move the title of the last song to the top of the page.
+                 */
+                padding-bottom: calc(100vh - 2em);
+                /* Same as Planning Center */
+                font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+                background-color: var(--background-color);
+                --background-color: hsl(0, 0, 98%);
+            }}
+            h2 {{
+                color: black;
+            }}
+            a {{
+                text-decoration: underline dotted black;
+            }}
+        </style>
+    </head>
+    <body>
+        {_indent(body, 2)}
+    </body>
+</html>
+    """
+
+
 def plan_summary_to_json(summary: PlanSummary) -> str:
     """
     Convert the plan summary to a JSON string.
@@ -1022,6 +1096,24 @@ def load_plan_summary(path: Path) -> PlanSummary:
         message_notes=message_notes,
         num_visuals_notes=data["num_visuals_notes"],
     )
+
+
+def vocals_notes_to_json(songs: List[AnnotatedSong]) -> str:
+    """
+    Convert the vocals notes summary to a JSON string.
+    This is the inverse of `load_vocals_notes_summary`.
+    """
+    json_summary = {"songs": [_annotated_song_to_json(s) for s in songs]}
+    return json.dumps(json_summary, indent="\t")
+
+
+def load_vocals_notes(path: Path) -> List[AnnotatedSong]:
+    """
+    Load a vocals notes summary from a JSON file.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return [_parse_annotated_song(s) for s in data["songs"]]
 
 
 def _cast(t: Type[T], x: object) -> T:

--- a/scripts/summarize_vocals_notes.bat
+++ b/scripts/summarize_vocals_notes.bat
@@ -1,0 +1,9 @@
+@ECHO OFF
+@TITLE Summarize Vocals Notes
+
+:: You need to pass the /D flag because the MCR computer uses the D:/ drive.
+CD /D %~dp0
+
+:: Start the command without a terminal window
+start pythonw summarize_vocals_notes.py
+wait_for_start.bat

--- a/scripts/summarize_vocals_notes.command
+++ b/scripts/summarize_vocals_notes.command
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Go to the scripts directory
+cd "$(dirname "$0")"
+
+python3 summarize_vocals_notes.py $* &

--- a/scripts/summarize_vocals_notes.py
+++ b/scripts/summarize_vocals_notes.py
@@ -1,0 +1,110 @@
+import sys
+import traceback
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
+from typing import Callable
+
+import autochecklist
+import external_services
+import lib
+from args import ReccArgs
+from autochecklist import Messenger, ProblemLevel, TaskModel, TaskStatus
+from config import Config
+from external_services import PlanningCenterClient
+from lib import ReccDependencyProvider, SimplifiedMessengerSettings
+
+_DEMO_FILE = Path(__file__).parent.joinpath(
+    "test", "integration", "summarize_plan_data", "20240505_vocals_notes.json"
+)
+
+
+class SummarizeVocalsNotesArgs(ReccArgs):
+    NAME = "summarize_vocals_notes"
+    DESCRIPTION = (
+        "This script will generate a summary of the vocals notes in today's service."
+    )
+
+    def __init__(self, args: Namespace, error: Callable[[str], None]) -> None:
+        self.no_open: bool = args.no_open
+        self.demo: bool = args.demo
+        super().__init__(args, error)
+
+    @classmethod
+    def set_up_parser(cls, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--no-open",
+            action="store_true",
+            help="Do not open the summary in the browser.",
+        )
+        parser.add_argument(
+            "--demo",
+            action="store_true",
+            help="Show a summary of a previous service to show the appearance, rather than pulling up-to-date data from Planning Center.",
+        )
+        return super().set_up_parser(parser)
+
+
+def summarize_vocals_notes(
+    pco_client: PlanningCenterClient,
+    args: SummarizeVocalsNotesArgs,
+    config: Config,
+    messenger: Messenger,
+) -> None:
+    if args.demo:
+        summary = lib.load_vocals_notes(_DEMO_FILE)
+    else:
+        summary = lib.get_vocals_notes(
+            client=pco_client,
+            config=config,
+            dt=config.start_time.date(),
+        )
+    html = lib.vocals_notes_to_html(summary)
+    config.vocals_notes_file.parent.mkdir(parents=True, exist_ok=True)
+    config.vocals_notes_file.write_text(str(html), encoding="utf-8")
+    url = config.vocals_notes_file.resolve().as_uri()
+    try:
+        fname = config.vocals_notes_file.relative_to(config.home_dir).as_posix()
+    except ValueError:
+        fname = config.vocals_notes_file.as_posix()
+    messenger.log_status(TaskStatus.DONE, f"Saved summary at [[url|{url}|{fname}]].")
+    if not args.no_open:
+        try:
+            external_services.launch_firefox(config.vocals_notes_file.as_posix())
+        except Exception as e:
+            messenger.log_problem(
+                ProblemLevel.WARN,
+                f"Failed to open summary in Firefox: {e}.",
+                traceback.format_exc(),
+            )
+
+
+def main(
+    args: SummarizeVocalsNotesArgs, config: Config, dep: ReccDependencyProvider
+) -> None:
+    tasks = TaskModel(
+        "summarize_vocals_notes",
+        description="Failed to generate summary.",
+        only_auto=True,
+    )
+    autochecklist.run(
+        args=args,
+        config=config,
+        dependency_provider=dep,
+        tasks=tasks,
+        module=sys.modules[__name__],
+    )
+
+
+if __name__ == "__main__":
+    _args = SummarizeVocalsNotesArgs.parse(sys.argv)
+    _cfg = Config(_args)
+    msg = SimplifiedMessengerSettings(
+        log_file=_cfg.summarize_plan_log,
+        script_name="Summarize Plan",
+        description=SummarizeVocalsNotesArgs.DESCRIPTION,
+        show_statuses_by_default=True,
+    )
+    dependency_provider = ReccDependencyProvider(
+        args=_args, config=_cfg, messenger=msg, lazy_login=_args.demo
+    )
+    main(_args, _cfg, dependency_provider)

--- a/scripts/test/integration/summarize_plan_data/20240505_vocals_notes.json
+++ b/scripts/test/integration/summarize_plan_data/20240505_vocals_notes.json
@@ -1,0 +1,74 @@
+{
+	"songs": [
+		{
+			"song": {
+				"ccli": null,
+				"title": "Come Now Is The Time To Worship (C to A)",
+				"author": null
+			},
+			"description": "CCLI Song # 2430948",
+			"notes": [
+				{
+					"category": "Vocals",
+					"contents": "Lead: Rodger\nMelody: Iris (boost during last half of the song after we modulate in key of A)\nHarmony: Kristina"
+				}
+			]
+		},
+		{
+			"song": {
+				"ccli": null,
+				"title": "Miracle / All Hail King Jesus (C)",
+				"author": null
+			},
+			"description": "Miracle: CCLI Song # 7118762\nAll Hail King Jesus: CCLI Song # 7097216",
+			"notes": [
+				{
+					"category": "Vocals",
+					"contents": "Lead: Kristina\nInstrumental V1 chords during MC Hosts speaking\nIntro\nV1 - Kristina\nChorus - Kristina\nTurnaround\nV2 - All (uni)\nChorus - All (harms)\nBridge\n(2X) All Hail King Jesus Chorus 1A (harms)\n(1X) All Hail King Jesus Chorus 1B\nTurnaround\nV3 - Kristina (first 2 lines) / (last 2 lines all in - harms)\n(2X) All Hail King Jesus Chorus 1A (harms)\n(1X) All Hail King Jesus Chorus 1B"
+				}
+			]
+		},
+		{
+			"song": {
+				"ccli": null,
+				"title": "How Deep The Father's Love For Us / He Lives (B)",
+				"author": null
+			},
+			"description": "How Deep The Father's Love For Us: CCLI Song # 1558110\nHe Lives: CCLI Song # 7133098",
+			"notes": [
+				{
+					"category": "Vocals",
+					"contents": "Lead: Iris / Harmony: Kristina\nInstrumental V1 of What a Beautiful Name during communion\nV1 - Iris & Rodger\nTurnaround\nV2 - All (harms)\nTurnaround\nV3 - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\n(2X) He Lives Bridge  - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\nV1 - Iris & Rodger\nStay on B to transition to What a Beautiful Name"
+				}
+			]
+		},
+		{
+			"song": {
+				"ccli": null,
+				"title": "What a Beautiful Name / Agnus Dei (B)",
+				"author": null
+			},
+			"description": "What a Beautiful Name: CCLI Song # 7068424\nAgnus Dei: CCLI Song # 626713",
+			"notes": [
+				{
+					"category": "Vocals",
+					"contents": "Lead: Kristina\nV1 - Kristina\nChorus 1 - Kristina\nV2 - All (harms)\nChorus 2 - All (harms)\nInstrumental\nBridge 1 - Kristina\nBridge 2 - All (harms)\nChorus 3 - All (harms)\nBridge 2 - All (harms) \n(2X) Agnus Dei Chorus - All (harms)\nChorus 1 - Kristina\nlast line tag 2X - Kristina"
+				}
+			]
+		},
+		{
+			"song": {
+				"ccli": null,
+				"title": "Worthy Of It All / I Exalt Thee (B)",
+				"author": null
+			},
+			"description": "Worthy Of It All: CCLI Song #6280644\nI Exalt Thee: CCLI Song #17803",
+			"notes": [
+				{
+					"category": "Vocals",
+					"contents": "Instrumental V1 of What a Beautiful Name during communion\nV1 - Iris & Rodger\nTurnaround\nV2 - All (harms)\nTurnaround\nV3 - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\nV1 - Iris & Rodger\n(2X) He Lives - Chorus - All (harms)\nStay on B to transition to What a Beautiful Name"
+				}
+			]
+		}
+	]
+}

--- a/scripts/test/integration/test_summarize_plan.py
+++ b/scripts/test/integration/test_summarize_plan.py
@@ -722,12 +722,12 @@ class PlanSummaryJsonTestCase(PlanSummaryTestCase):
         n = 0
         for p in _DATA_DIR.glob("*_summary.json"):
             with self.subTest(p.stem):
+                n += 1
                 summary1 = load_plan_summary(p)
                 temp_file = _TEMP_DIR.joinpath(p.relative_to(_DATA_DIR))
                 temp_file.write_text(plan_summary_to_json(summary1))
                 summary2 = load_plan_summary(temp_file)
                 self.assert_equal_summary(summary1, summary2)
-        n += 1
         # At least one test must have run, otherwise there's something wrong
         # with the test itself
         self.assertGreater(n, 0)

--- a/scripts/test/integration/test_summarize_plan.py
+++ b/scripts/test/integration/test_summarize_plan.py
@@ -29,6 +29,7 @@ from lib import (
     PlanSummaryDiff,
     diff_plan_summaries,
     get_plan_summary,
+    get_vocals_notes,
     load_plan_summary,
     plan_summary_diff_to_html,
     plan_summary_to_json,
@@ -730,6 +731,115 @@ class PlanSummaryJsonTestCase(PlanSummaryTestCase):
         # At least one test must have run, otherwise there's something wrong
         # with the test itself
         self.assertGreater(n, 0)
+
+
+class GetVocalsNotesTestCase(unittest.TestCase):
+    """Test `get_vocals_notes()`."""
+
+    def setUp(self):
+        # TODO: Make a helper method for this (copied from
+        #       GeneratePlanSummaryTestCase)?
+        super().setUp()
+
+        self._config = Config(
+            args=ReccArgs.parse([]),
+            profile="foh_dev",
+            allow_multiple_only_for_testing=True,
+        )
+        credential_store = create_autospec(CredentialStore)
+        self._messenger = create_autospec(Messenger)
+        self._log_problem_mock = self._messenger.log_problem
+        self._pco_client = PlanningCenterClient(
+            messenger=self._messenger,
+            credential_store=credential_store,
+            config=self._config,
+            lazy_login=True,
+        )
+        self._pco_client._send_and_check_status = (  # pyright: ignore[reportPrivateUsage]
+            get_canned_response
+        )
+
+    def test_get_vocals_notes_20240505(self) -> None:
+        expected_notes = [
+            AnnotatedSong(
+                song=Song(
+                    ccli=None,
+                    title="Come Now Is The Time To Worship (C to A)",
+                    author=None,
+                ),
+                notes=[
+                    ItemNote(
+                        category="Vocals",
+                        contents="Lead: Rodger\nMelody: Iris (boost during last half of the song after we modulate in key of A)\nHarmony: Kristina",
+                    )
+                ],
+                description="CCLI Song # 2430948",
+            ),
+            AnnotatedSong(
+                song=Song(
+                    ccli=None,
+                    title="Miracle / All Hail King Jesus (C)",
+                    author=None,
+                ),
+                notes=[
+                    ItemNote(
+                        category="Vocals",
+                        contents="Lead: Kristina\nInstrumental V1 chords during MC Hosts speaking\nIntro\nV1 - Kristina\nChorus - Kristina\nTurnaround\nV2 - All (uni)\nChorus - All (harms)\nBridge\n(2X) All Hail King Jesus Chorus 1A (harms)\n(1X) All Hail King Jesus Chorus 1B\nTurnaround\nV3 - Kristina (first 2 lines) / (last 2 lines all in - harms)\n(2X) All Hail King Jesus Chorus 1A (harms)\n(1X) All Hail King Jesus Chorus 1B",
+                    )
+                ],
+                description="Miracle: CCLI Song # 7118762\nAll Hail King Jesus: CCLI Song # 7097216",
+            ),
+            AnnotatedSong(
+                song=Song(
+                    ccli=None,
+                    title="How Deep The Father's Love For Us / He Lives (B)",
+                    author=None,
+                ),
+                notes=[
+                    ItemNote(
+                        category="Vocals",
+                        contents="Lead: Iris / Harmony: Kristina\nInstrumental V1 of What a Beautiful Name during communion\nV1 - Iris & Rodger\nTurnaround\nV2 - All (harms)\nTurnaround\nV3 - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\n(2X) He Lives Bridge  - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\nV1 - Iris & Rodger\nStay on B to transition to What a Beautiful Name",
+                    )
+                ],
+                description="How Deep The Father's Love For Us: CCLI Song # 1558110\nHe Lives: CCLI Song # 7133098",
+            ),
+            AnnotatedSong(
+                song=Song(
+                    ccli=None,
+                    title="What a Beautiful Name / Agnus Dei (B)",
+                    author=None,
+                ),
+                notes=[
+                    ItemNote(
+                        category="Vocals",
+                        contents="Lead: Kristina\nV1 - Kristina\nChorus 1 - Kristina\nV2 - All (harms)\nChorus 2 - All (harms)\nInstrumental\nBridge 1 - Kristina\nBridge 2 - All (harms)\nChorus 3 - All (harms)\nBridge 2 - All (harms) \n(2X) Agnus Dei Chorus - All (harms)\nChorus 1 - Kristina\nlast line tag 2X - Kristina",
+                    )
+                ],
+                description="What a Beautiful Name: CCLI Song # 7068424\nAgnus Dei: CCLI Song # 626713",
+            ),
+            AnnotatedSong(
+                song=Song(
+                    ccli=None,
+                    title="Worthy Of It All / I Exalt Thee (B)",
+                    author=None,
+                ),
+                notes=[
+                    ItemNote(
+                        category="Vocals",
+                        contents="Instrumental V1 of What a Beautiful Name during communion\nV1 - Iris & Rodger\nTurnaround\nV2 - All (harms)\nTurnaround\nV3 - All (harms)\n(2X) He Lives - Chorus - All (harms)\nHe Lives (Instrumental)\nV1 - Iris & Rodger\n(2X) He Lives - Chorus - All (harms)\nStay on B to transition to What a Beautiful Name",
+                    )
+                ],
+                description="Worthy Of It All: CCLI Song #6280644\nI Exalt Thee: CCLI Song #17803",
+            ),
+        ]
+        actual_notes = get_vocals_notes(
+            client=self._pco_client,
+            config=self._config,
+            dt=date(2024, 5, 5),
+        )
+
+        self.assertEqual(actual_notes, expected_notes)
+        self._log_problem_mock.assert_not_called()
 
 
 def _get_clipboard_text() -> str:


### PR DESCRIPTION
The visuals notes on the PCO live view are really hard to read; everything is on one line.

Now, there is a new script which can generate an HTML page showing the notes for each song in a more readable way.